### PR TITLE
Add vaccination summary script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **Capstone Project: Evaluating the Impact of the Vaccination Process on the Incidence of COVID-19 Cases, Hospitalizations, and Deaths in Chile**
 
-**Objective:** 
+**Objective:**
 To investigate the relationship between the mass vaccination campaign in Chile and the subsequent reduction in the incidence of COVID-19 cases, hospitalizations, and deaths.
 
-**Background:** 
+**Background:**
 The global outbreak of the COVID-19 virus led nations worldwide to urgently seek solutions to curb its spread. Chile, like many other countries, initiated a mass vaccination campaign, hoping to reduce the severe consequences associated with the virus. Anecdotal evidence and preliminary data suggest a notable decrease in the incidence of cases, hospitalizations, and deaths post-vaccination. However, a comprehensive analysis is required to draw statistically significant conclusions.
 
 **Hypothesis:**
@@ -14,9 +14,7 @@ We believe that the mass vaccination campaign has significantly contributed to a
 **Significance:**
 
 1. **Reinforcing Trust:** If this study can demonstrate a strong correlation or causation between vaccination and reduced COVID-19 consequences, it will bolster public confidence in vaccines and the science underpinning them.
-
 2. **Informed Decision-making:** Authorities can utilize the findings from this research to make informed decisions regarding the continuation, modification, or expansion of vaccination campaigns in the present and future.
-
 3. **Clarity for the Public:** Understanding the tangible benefits of vaccination campaigns provides society with a clearer picture of the path forward. This clarity can guide individual choices, public policy decisions, and collective sentiments towards a return to normalcy.
 
 **Methodology:**
@@ -24,3 +22,18 @@ The study will employ a combination of quantitative research methods, analyzing 
 
 **Expected Outcome:**
 Through this research, we aim to provide clear, data-driven insights into the effects of the vaccination campaign in Chile, paving the way for informed decisions in both health policy and public perception.
+
+## Usage
+
+A small helper script, `summarize_vaccinations.py`, summarizes total doses per manufacturer using only the Python standard library.
+
+```bash
+python summarize_vaccinations.py
+```
+
+Pass an explicit path to the dataset if it is located elsewhere:
+
+```bash
+python summarize_vaccinations.py path/to/Vacunas.csv
+```
+

--- a/summarize_vaccinations.py
+++ b/summarize_vaccinations.py
@@ -1,0 +1,64 @@
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable
+import csv
+
+DOSE_COLUMNS = [
+    "Primera Dosis",
+    "Segunda Dosis",
+    "Dosis Refuerzo",
+    "Cuarta Dosis",
+    "Dosis Única",
+]
+
+
+def load_vaccination_data(csv_path: Path) -> Iterable[Dict[str, str]]:
+    """Yield rows from the vaccination CSV file as dictionaries."""
+    with csv_path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            yield row
+
+
+def total_doses_by_manufacturer(rows: Iterable[Dict[str, str]]) -> Dict[str, Dict[str, float]]:
+    """Compute total doses per manufacturer using only the standard library."""
+    totals: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for row in rows:
+        manufacturer = row.get("Fabricante", "Desconocido") or "Desconocido"
+        for col in DOSE_COLUMNS:
+            try:
+                value = float(row.get(col, 0) or 0)
+            except ValueError:
+                value = 0.0
+            totals[manufacturer][col] += value
+    return totals
+
+
+def main(csv_path: Path) -> None:
+    rows = load_vaccination_data(csv_path)
+    totals = total_doses_by_manufacturer(rows)
+    # Sort manufacturers by first dose count in descending order
+    sorted_manufacturers = sorted(
+        totals.items(), key=lambda item: item[1]["Primera Dosis"], reverse=True
+    )
+    header = ["Fabricante"] + DOSE_COLUMNS
+    print(",".join(header))
+    for manufacturer, counts in sorted_manufacturers:
+        values = [f"{counts[col]:.0f}" for col in DOSE_COLUMNS]
+        print(",".join([manufacturer] + values))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Summarize Chile COVID-19 vaccination dataset by manufacturer."
+    )
+    parser.add_argument(
+        "csv_path",
+        nargs="?",
+        default="Vacunas.csv",
+        type=Path,
+        help="Path to the Vacunas.csv dataset.",
+    )
+    args = parser.parse_args()
+    main(args.csv_path)


### PR DESCRIPTION
## Summary
- add `summarize_vaccinations.py` script to compute total doses by vaccine manufacturer using only the Python standard library
- document the helper script and usage in README

## Testing
- `python summarize_vaccinations.py`
- `python -m py_compile summarize_vaccinations.py`


------
https://chatgpt.com/codex/tasks/task_e_68a54e7a06d083309a8476d73107a5a3